### PR TITLE
bugfix/migrate-orderer-context

### DIFF
--- a/Server/routes.js
+++ b/Server/routes.js
@@ -32,10 +32,7 @@ module.exports = (app, context) => {
         OrdererController.tlsRegisterEnroll,
         OrdererController.orgRegisterEnroll,
         OrdererController.startOrderer,
-        async (req, res) => {
-            await context.writeNode(req.ordererNode);
-            res.send("\nok");
-        });
+        OrdererController.updateContext);
 
     app.post(`/joinChannel`,
         PeerController.getPeer,


### PR DESCRIPTION
#31 /initOrderer endpoint is now using updateContext middleware.